### PR TITLE
Fix datetime init value

### DIFF
--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -120,7 +120,7 @@ class ItemsController extends Controller
             if ( $model->load(Yii::$app->request->post()) )
             {
                 // Set Modified as actual date
-                $model->modified = "0000-00-00 00:00:00";
+                $model->modified = "1970-01-01 00:00:01";
 
                 // If alias is not set, generate it
                 if ($_POST['Items']['alias']=="")


### PR DESCRIPTION
If we write 0000-00-00 00:00:00 we received 

> Incorrect datetime value: '0000-00-00 00:00:00' for column

According to [MySQL DOC](http://dev.mysql.com/doc/refman/5.5/en/datetime.html):

>  The DATE type is used for values with a date part but no time part. MySQL retrieves and displays DATE values in 'YYYY-MM-DD' format. The supported range is '1000-01-01' to '9999-12-31'.
>
> The DATETIME type is used for values that contain both date and time parts. MySQL retrieves and displays DATETIME values in 'YYYY-MM-DD HH:MM:SS' format. The supported range is '1000-01-01 00:00:00' to '9999-12-31 23:59:59'.
>
> The TIMESTAMP data type is used for values that contain both date and time parts. TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC. 
